### PR TITLE
Allow direct input of reference score in game settings

### DIFF
--- a/arc-arsenal/src/app/components/settings/settings.component.html
+++ b/arc-arsenal/src/app/components/settings/settings.component.html
@@ -67,7 +67,7 @@
                 <button class="button is-small" (click)="decrementReferenceScore()">-</button>
             </p>
             <p class="control">
-                <input class="input is-small has-text-centered" readonly [value]="referenceScore" style="width: 60px" />
+                <input class="input is-small has-text-centered" type="number" min="1" [value]="referenceScore" (change)="setReferenceScore($event)" style="width: 60px" />
             </p>
             <p class="control">
                 <button class="button is-small" (click)="incrementReferenceScore()">+</button>

--- a/arc-arsenal/src/app/components/settings/settings.component.scss
+++ b/arc-arsenal/src/app/components/settings/settings.component.scss
@@ -1,0 +1,7 @@
+input[type=number] {
+  -moz-appearance: textfield;
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+  }
+}

--- a/arc-arsenal/src/app/components/settings/settings.component.ts
+++ b/arc-arsenal/src/app/components/settings/settings.component.ts
@@ -76,6 +76,15 @@ export class SettingsComponent {
     }
   }
 
+  setReferenceScore(event: Event) {
+    const v = parseInt((event.target as HTMLInputElement).value, 10);
+    if (!isNaN(v) && v > 0) {
+      this.referenceScore = v;
+    } else {
+      (event.target as HTMLInputElement).value = String(this.referenceScore);
+    }
+  }
+
   saveSettings() {
     let settings: { arrowsPerEndShotCount?: number, endsCount?: number, arrowsPerEndCount?: number, successZone?: number, referenceScore?: number } = {
     };


### PR DESCRIPTION
The reference score field was readonly, requiring many +/- clicks to reach a target value. Now accepts direct numeric input with validation (resets to previous value if invalid). Native spinner arrows hidden via CSS since +/- buttons already serve that purpose.