### PR TITLE
Add target face type (anglais/campagne) to tir compté games

### DIFF
--- a/arc-arsenal/src/app/components/score-input/keyboard/keyboard.component.html
+++ b/arc-arsenal/src/app/components/score-input/keyboard/keyboard.component.html
@@ -1,6 +1,6 @@
 <div class="keyboard">
   <div class="columns is-multiline is-mobile is-1">
-    <div *ngFor="let value of values" class="column is-one-quarter">
+    <div *ngFor="let value of values" class="column" [ngClass]="columnClass">
       <button
         class="button custom-key"
         [ngClass]="getScoreClass(value)"

--- a/arc-arsenal/src/app/components/score-input/keyboard/keyboard.component.ts
+++ b/arc-arsenal/src/app/components/score-input/keyboard/keyboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 
 @Component({
   selector: 'app-score-keyboard',
@@ -10,25 +10,21 @@ import { getScoreClass } from '../../../utils/score-utils';
   styleUrl: './keyboard.component.scss'
 })
 export class ScoreKeyboardComponent {
+  @Input() blasonType: BlasonType = 'anglais';
   @Output() scoreSelected = new EventEmitter<number | 'X' | 'M'>();
-  values: (number | 'X' | 'M')[] = [
-    'X',
-    10,
-    9,
-    8,
-    7,
-    6,
-    5,
-    4,
-    3,
-    2,
-    1,
-    'M',
-  ];
+
+  get values(): (number | 'X' | 'M')[] {
+    if (this.blasonType === 'campagne') return [6, 5, 4, 3, 2, 1, 'M'];
+    return ['X', 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 'M'];
+  }
+
+  get columnClass(): string {
+    return this.blasonType === 'campagne' ? 'is-one-third' : 'is-one-quarter';
+  }
+
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   selectScore(value: number | 'X' | 'M') {
     this.scoreSelected.emit(value);
   }
-
-  getScoreClass = getScoreClass;
 }

--- a/arc-arsenal/src/app/components/settings/settings.component.html
+++ b/arc-arsenal/src/app/components/settings/settings.component.html
@@ -75,6 +75,18 @@
         </div>
     </div>
 
+    <div class="field mb-4" *ngIf="showBlasonToggle">
+        <label class="label">Type de blason :</label>
+        <div class="field has-addons is-justify-content-center">
+            <p class="control">
+                <button class="button is-small" [class.is-primary]="blasonType === 'anglais'" (click)="blasonType = 'anglais'">Anglais</button>
+            </p>
+            <p class="control">
+                <button class="button is-small" [class.is-primary]="blasonType === 'campagne'" (click)="blasonType = 'campagne'">Campagne</button>
+            </p>
+        </div>
+    </div>
+
     <div class="has-text-centered mt-4">
         <button class="button is-primary" (click)="saveSettings()">Démarrer</button>
     </div>

--- a/arc-arsenal/src/app/components/settings/settings.component.ts
+++ b/arc-arsenal/src/app/components/settings/settings.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { BlasonType } from '../../utils/score-utils';
 
 @Component({
   selector: 'app-game-settings',
@@ -15,8 +16,11 @@ export class SettingsComponent {
   @Input() minimumArrowsPerEnd: number = 3; // Default value, can be overridden by input
   @Input() successZone?: number; // Default value, can be overridden by input
   @Input() referenceScore?: number; // Default value, can be overridden by input
+  @Input() showBlasonToggle: boolean = false;
 
-  @Output() newSettings = new EventEmitter<{ arrowsPerEndShotCount?: number, endsCount?: number, arrowsPerEndCount?: number, successZone?: number, referenceScore?: number } | null>();
+  blasonType: BlasonType = 'anglais';
+
+  @Output() newSettings = new EventEmitter<{ arrowsPerEndShotCount?: number, endsCount?: number, arrowsPerEndCount?: number, successZone?: number, referenceScore?: number, blasonType?: BlasonType } | null>();
 
   incrementArrowsShotCount() {
     if (this.arrowsPerEndShotCount) {
@@ -86,7 +90,7 @@ export class SettingsComponent {
   }
 
   saveSettings() {
-    let settings: { arrowsPerEndShotCount?: number, endsCount?: number, arrowsPerEndCount?: number, successZone?: number, referenceScore?: number } = {
+    let settings: { arrowsPerEndShotCount?: number, endsCount?: number, arrowsPerEndCount?: number, successZone?: number, referenceScore?: number, blasonType?: BlasonType } = {
     };
     if (this.arrowsPerEndShotCount) {
       settings.arrowsPerEndShotCount = this.arrowsPerEndShotCount;
@@ -103,6 +107,7 @@ export class SettingsComponent {
     if (this.referenceScore !== undefined) {
       settings.referenceScore = this.referenceScore;
     }
+    settings.blasonType = this.blasonType;
     this.newSettings.emit(settings);
   }
 }

--- a/arc-arsenal/src/app/pages/games/big-ten/big-ten.component.html
+++ b/arc-arsenal/src/app/pages/games/big-ten/big-ten.component.html
@@ -59,4 +59,4 @@
 </div>
 
 <!-- Keyboard -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/big-ten/big-ten.component.ts
+++ b/arc-arsenal/src/app/pages/games/big-ten/big-ten.component.ts
@@ -5,7 +5,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { SettingsComponent } from "../../../components/settings/settings.component";
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 import { PastGamesComponent } from "../../../components/past-games/past-games.component";
 import { GameService } from '../../../services/game.service';
 import { AuthService } from '../../../services/auth.service';
@@ -28,6 +28,7 @@ export class BigTenGameComponent implements OnDestroy{
   endsCount: number = 6;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -48,6 +49,7 @@ export class BigTenGameComponent implements OnDestroy{
     if (settings) {
       this.arrowsPerEndShotCount = settings.arrowsPerEndShotCount;
       this.endsCount = settings.endsCount;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -108,7 +110,7 @@ export class BigTenGameComponent implements OnDestroy{
     }
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   calculateScoreSum(scores: (number | 'X' | 'M')[]): number {
     return scores.reduce((total: number, s) => {

--- a/arc-arsenal/src/app/pages/games/double-counted-shot/double-counted-shot.component.html
+++ b/arc-arsenal/src/app/pages/games/double-counted-shot/double-counted-shot.component.html
@@ -4,9 +4,9 @@
 </h1>
 
 <!-- Settings -->
-<app-game-settings *ngIf="!gameStarted" [arrowsPerEndShotCount]="arrowsPerEndShotCount" 
-  [arrowsPerEndCount]="arrowsPerEndCount" [endsCount]="endsCount"
- (newSettings)="onNewSettings($event)"></app-game-settings>
+<app-game-settings *ngIf="!gameStarted" [arrowsPerEndShotCount]="arrowsPerEndShotCount"
+  [arrowsPerEndCount]="arrowsPerEndCount" [endsCount]="endsCount" [showBlasonToggle]="true"
+  (newSettings)="onNewSettings($event)"></app-game-settings>
 
 <!-- Past games -->
 <app-past-games
@@ -61,4 +61,4 @@
 </div>
 
 <!-- Clavier -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/double-counted-shot/double-counted-shot.component.ts
+++ b/arc-arsenal/src/app/pages/games/double-counted-shot/double-counted-shot.component.ts
@@ -6,7 +6,7 @@ import { faRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { PastGamesComponent } from "../../../components/past-games/past-games.component";
 import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard/keyboard.component';
 import { SettingsComponent } from "../../../components/settings/settings.component";
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 import { GameService } from '../../../services/game.service';
 import { AuthService } from '../../../services/auth.service';
 
@@ -28,6 +28,7 @@ export class DoubleCountedShotGameComponent {
   endsCount: number = 6;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -50,6 +51,7 @@ export class DoubleCountedShotGameComponent {
       this.arrowsPerEndShotCount = settings.arrowsPerEndShotCount;
       this.arrowsPerEndCount = settings.arrowsPerEndCount!;
       this.endsCount = settings.endsCount;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -112,7 +114,7 @@ export class DoubleCountedShotGameComponent {
     }
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   calculateScoreSum(scores: (number | 'X' | 'M')[]): number {
     return scores.reduce((total: number, s) => {

--- a/arc-arsenal/src/app/pages/games/dynamic-ref-end-score/dynamic-ref-end-score.component.html
+++ b/arc-arsenal/src/app/pages/games/dynamic-ref-end-score/dynamic-ref-end-score.component.html
@@ -119,4 +119,4 @@
 </div>
 
 <!-- Keyboard -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/dynamic-ref-end-score/dynamic-ref-end-score.component.ts
+++ b/arc-arsenal/src/app/pages/games/dynamic-ref-end-score/dynamic-ref-end-score.component.ts
@@ -8,7 +8,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { SettingsComponent } from "../../../components/settings/settings.component";
 import { AuthService } from '../../../services/auth.service';
 import { GameService } from '../../../services/game.service';
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 
 @Component({
   standalone: true,
@@ -31,6 +31,7 @@ export class DynamicRefEndScoreComponent {
   referenceScore: number = 45; // Initial reference score for the first end
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -76,6 +77,7 @@ export class DynamicRefEndScoreComponent {
       this.arrowsPerEndShotCount = settings.arrowsPerEndShotCount;
       this.endsCount = settings.endsCount;
       this.referenceScore = settings.referenceScore;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -108,7 +110,7 @@ export class DynamicRefEndScoreComponent {
     this.gameFinished = data.gameFinished || false;
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
 
   addScore(score: number | 'X' | 'M') {

--- a/arc-arsenal/src/app/pages/games/gold-game/gold-game.component.html
+++ b/arc-arsenal/src/app/pages/games/gold-game/gold-game.component.html
@@ -100,4 +100,4 @@
 </div>
 
 <!-- Keyboard -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/gold-game/gold-game.component.ts
+++ b/arc-arsenal/src/app/pages/games/gold-game/gold-game.component.ts
@@ -8,7 +8,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { SettingsComponent } from "../../../components/settings/settings.component";
 import { AuthService } from '../../../services/auth.service';
 import { GameService } from '../../../services/game.service';
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 
 @Component({
   selector: 'app-gold-game',
@@ -32,6 +32,7 @@ export class GoldGameComponent {
   successZone: number = 7;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -59,6 +60,7 @@ export class GoldGameComponent {
       this.arrowsPerEndCount = settings.arrowsPerEndShotCount;
       this.endsCount = settings.endsCount;
       this.successZone = settings.successZone;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -113,7 +115,7 @@ export class GoldGameComponent {
     }
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   calculateScore(scores: (number | 'X' | 'M')[]): number {
     return scores.reduce((total: number, s) => {

--- a/arc-arsenal/src/app/pages/games/simple-counted-shot/simple-counted-shot.component.html
+++ b/arc-arsenal/src/app/pages/games/simple-counted-shot/simple-counted-shot.component.html
@@ -5,7 +5,7 @@
 
 <!-- Settings-->
 <app-game-settings *ngIf="!gameStarted" [arrowsPerEndShotCount]="arrowsPerEndShotCount" [minimumArrowsPerEnd]="3"
-  [endsCount]="endsCount" (newSettings)="onNewSettings($event)"></app-game-settings>
+  [endsCount]="endsCount" [showBlasonToggle]="true" (newSettings)="onNewSettings($event)"></app-game-settings>
 
 <!-- Past games -->
 <app-past-games
@@ -59,4 +59,4 @@
 </div>
 
 <!-- Keyboard -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/simple-counted-shot/simple-counted-shot.component.ts
+++ b/arc-arsenal/src/app/pages/games/simple-counted-shot/simple-counted-shot.component.ts
@@ -5,7 +5,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { SettingsComponent } from "../../../components/settings/settings.component";
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 import { PastGamesComponent } from "../../../components/past-games/past-games.component";
 import { GameService } from '../../../services/game.service';
 import { AuthService } from '../../../services/auth.service';
@@ -28,6 +28,7 @@ export class SimpleCountedShotGameComponent implements OnDestroy{
   endsCount: number = 6;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -48,6 +49,7 @@ export class SimpleCountedShotGameComponent implements OnDestroy{
     if (settings) {
       this.arrowsPerEndShotCount = settings.arrowsPerEndShotCount;
       this.endsCount = settings.endsCount;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -108,7 +110,7 @@ export class SimpleCountedShotGameComponent implements OnDestroy{
     }
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   calculateScoreSum(scores: (number | 'X' | 'M')[]): number {
     return scores.reduce((total: number, s) => {

--- a/arc-arsenal/src/app/pages/games/static-ref-end-score/static-ref-end-score.component.html
+++ b/arc-arsenal/src/app/pages/games/static-ref-end-score/static-ref-end-score.component.html
@@ -102,4 +102,4 @@
   </div>
 </div>
 
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/static-ref-end-score/static-ref-end-score.component.ts
+++ b/arc-arsenal/src/app/pages/games/static-ref-end-score/static-ref-end-score.component.ts
@@ -8,7 +8,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { SettingsComponent } from "../../../components/settings/settings.component";
 import { AuthService } from '../../../services/auth.service';
 import { GameService } from '../../../services/game.service';
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 
 @Component({
   standalone: true,
@@ -31,6 +31,7 @@ export class StaticRefEndScoreComponent {
   referenceScore: number = 45;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -77,6 +78,7 @@ export class StaticRefEndScoreComponent {
       this.arrowsPerEndShotCount = settings.arrowsPerEndShotCount;
       this.endsCount = settings.endsCount;
       this.referenceScore = settings.referenceScore;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -109,7 +111,7 @@ export class StaticRefEndScoreComponent {
     this.gameFinished = data.gameFinished || false;
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   addScore(score: number | 'X' | 'M') {
     if (this.currentEnd.length < this.arrowsPerEndShotCount) {

--- a/arc-arsenal/src/app/pages/games/zone-game/zone-game.component.html
+++ b/arc-arsenal/src/app/pages/games/zone-game/zone-game.component.html
@@ -91,4 +91,4 @@
 </div>
 
 <!-- Keyboard -->
-<app-score-keyboard *ngIf="gameStarted && !gameFinished" (scoreSelected)="addScore($event)"></app-score-keyboard>
+<app-score-keyboard *ngIf="gameStarted && !gameFinished" [blasonType]="blasonType" (scoreSelected)="addScore($event)"></app-score-keyboard>

--- a/arc-arsenal/src/app/pages/games/zone-game/zone-game.component.ts
+++ b/arc-arsenal/src/app/pages/games/zone-game/zone-game.component.ts
@@ -8,7 +8,7 @@ import { ScoreKeyboardComponent } from '../../../components/score-input/keyboard
 import { SettingsComponent } from "../../../components/settings/settings.component";
 import { AuthService } from '../../../services/auth.service';
 import { GameService } from '../../../services/game.service';
-import { getScoreClass } from '../../../utils/score-utils';
+import { BlasonType, getScoreClass as scoreClassFn } from '../../../utils/score-utils';
 
 @Component({
   selector: 'app-zone-game',
@@ -31,6 +31,7 @@ export class ZoneGameComponent {
   successZone: number = 7;
   gameStarted: boolean = false;
   gameFinished: boolean = false;
+  blasonType: BlasonType = 'anglais';
   currentEnd: (number | 'X' | 'M')[] = [];
   currentEndIndex: number = 0;
   pastEnds: {
@@ -57,6 +58,7 @@ export class ZoneGameComponent {
   async onNewSettings(settings: any | null) {
     if (settings) {
       this.successZone = settings.successZone;
+      this.blasonType = settings.blasonType ?? 'anglais';
       this.startGame();
     } else {
       await this.resetGame();
@@ -112,7 +114,7 @@ export class ZoneGameComponent {
     await this.gameService.addOrUpdatePastGame(gameData, this.localStorageItemName);
   }
 
-  getScoreClass = getScoreClass;
+  getScoreClass = (v: number | 'X' | 'M') => scoreClassFn(v, this.blasonType);
 
   calculateScore(scores: (number | 'X' | 'M')[]): number {
     const arrowsInZoneCount = scores.reduce((total: number, s) => {

--- a/arc-arsenal/src/app/utils/score-utils.ts
+++ b/arc-arsenal/src/app/utils/score-utils.ts
@@ -1,9 +1,17 @@
-export function getScoreClass(value: number | 'X' | 'M'): string {
-    if (value === 'X' || value === 10 || value === 9) return 'yellow';
-    if (value === 8 || value === 7) return 'red';
-    if (value === 6 || value === 5) return 'blue';
-    if (value === 4 || value === 3) return 'black';
-    if (value === 2 || value === 1) return 'white';
+export type BlasonType = 'anglais' | 'campagne';
+
+export function getScoreClass(value: number | 'X' | 'M', blasonType: BlasonType = 'anglais'): string {
+  if (blasonType === 'campagne') {
+    if (value === 6 || value === 5) return 'yellow';
+    if (value === 4 || value === 3 || value === 2 || value === 1) return 'black';
     if (value === 'M') return 'grey';
     return '';
+  }
+  if (value === 'X' || value === 10 || value === 9) return 'yellow';
+  if (value === 8 || value === 7) return 'red';
+  if (value === 6 || value === 5) return 'blue';
+  if (value === 4 || value === 3) return 'black';
+  if (value === 2 || value === 1) return 'white';
+  if (value === 'M') return 'grey';
+  return '';
 }


### PR DESCRIPTION
New toggle in game settings for "Tir compté" and "Tir compté double" lets archers choose between two target faces:
- Anglais: X, 10–1, M with standard FFTA colors (yellow/red/blue/black/white)
- Campagne: 6–1, M with field colors (yellow for 5–6, black for 1–4)

The choice drives the score keyboard values and layout (4 or 3 columns) and the color of all displayed arrows throughout the game.